### PR TITLE
feat: use agreed generic instructions wording

### DIFF
--- a/lib/forms/ADHD_ASRS_1.1/index.ts
+++ b/lib/forms/ADHD_ASRS_1.1/index.ts
@@ -94,8 +94,8 @@ export default defineInstrument({
     },
     estimatedDuration: 1,
     instructions: {
-      en: ['This is a self-rated instrument, please answer all questions.'],
-      fr: ["Il s'agit d'un instrument d'auto-évaluation, veuillez répondre à toutes les questions."]
+      en: ['Follow the instructions on the next page'],
+      fr: ['Suivez les instructions de la page suivante']
     },
     license: 'CC-BY-4.0',
     referenceUrl: 'http://www.hcp.med.harvard.edu/ncs/asrs.php',
@@ -105,7 +105,7 @@ export default defineInstrument({
     }
   },
   internal: {
-    edition: 1,
+    edition: 2,
     name: 'ADHD_ASRS_1.1'
   },
   kind: 'FORM',

--- a/lib/forms/AUDIT_C/index.ts
+++ b/lib/forms/AUDIT_C/index.ts
@@ -6,7 +6,7 @@ export default defineInstrument({
   language: ['en', 'fr'],
   internal: {
     name: 'AUDIT_C',
-    edition: 1
+    edition: 2
   },
   tags: {
     en: ['Alcohol', 'Health', 'Disorder'],
@@ -25,8 +25,8 @@ export default defineInstrument({
     },
     estimatedDuration: 2,
     instructions: {
-      en: ['Please respond to every question'],
-      fr: ['Veuillez répondre à toutes les questions']
+      en: ['Follow the instructions on the next page'],
+      fr: ['Suivez les instructions de la page suivante']
     },
     license: 'PUBLIC-DOMAIN',
     title: {
@@ -176,4 +176,3 @@ export default defineInstrument({
       }
     })
 });
-

--- a/lib/forms/CUDIT_R/index.ts
+++ b/lib/forms/CUDIT_R/index.ts
@@ -55,14 +55,14 @@ export default defineInstrument({
     fr: ['Cannabis', 'Dépendance', 'Abus de substance']
   },
   internal: {
-    edition: 1,
+    edition: 2,
     name: 'CUDIT_R'
   },
   clientDetails: {
     estimatedDuration: 10,
     instructions: {
-      en: ['Please fill out answer that best describe your cannabis usage.'],
-      fr: ['Veuillez remplir les réponses qui décrivent le mieux votre consommation de cannabis']
+      en: ['Follow the instructions on the next page'],
+      fr: ['Suivez les instructions de la page suivante']
     },
     title: {
       en: 'Cannabis Use Identification Test - Revised (CUDIT-R)',

--- a/lib/forms/FAGERSTRÖM_NICOTINE_DEPENDENCE/index.ts
+++ b/lib/forms/FAGERSTRÖM_NICOTINE_DEPENDENCE/index.ts
@@ -18,7 +18,7 @@ export default defineInstrument({
   language: ['en', 'fr'],
   internal: {
     name: 'FAGERSTRÖM_NICOTINE_DEPENDENCE',
-    edition: 1
+    edition: 2
   },
   tags: {
     en: ['smoking', 'addiction', 'nicotine'],
@@ -31,8 +31,8 @@ export default defineInstrument({
     },
     estimatedDuration: 5,
     instructions: {
-      en: ['Please respond to every question'],
-      fr: ['Veuillez répondre à toutes les questions']
+      en: ['Follow the instructions on the next page'],
+      fr: ['Suivez les instructions de la page suivante']
     },
     license: 'PUBLIC-DOMAIN',
     title: {

--- a/lib/forms/GAD_7/index.ts
+++ b/lib/forms/GAD_7/index.ts
@@ -39,8 +39,8 @@ export default defineInstrument({
     },
     estimatedDuration: 1,
     instructions: {
-      en: ['Please complete all questions'],
-      fr: ['Veuillez répondre à toutes les questions']
+      en: ['Follow the instructions on the next page'],
+      fr: ['Suivez les instructions de la page suivante']
     },
     license: 'PUBLIC-DOMAIN'
   },
@@ -52,7 +52,7 @@ export default defineInstrument({
   },
   internal: {
     name: 'GAD_7',
-    edition: 1
+    edition: 2
   },
   content: [
     {

--- a/lib/forms/OLDER_AMERICANS_RESOURCES_AND_SERVICES/index.ts
+++ b/lib/forms/OLDER_AMERICANS_RESOURCES_AND_SERVICES/index.ts
@@ -6,7 +6,7 @@ export default defineInstrument({
   language: ['en', 'fr'],
   internal: {
     name: 'OLDER_AMERICANS_RESOURCES_AND_SERVICES',
-    edition: 1
+    edition: 2
   },
   tags: {
     en: ['social'],
@@ -211,10 +211,8 @@ export default defineInstrument({
     },
     estimatedDuration: 3,
     instructions: {
-      en: ['Now, I would like to ask you some questions about your family and friends. Please complete all questions.'],
-      fr: [
-        "Maintenant, j'aimerais vous poser quelques questions sur votre famille et vos amis. Veuillez répondre à toutes les questions."
-      ]
+      en: ['Follow the instructions on the next page'],
+      fr: ['Suivez les instructions de la page suivante']
     },
     license: 'CC-BY-4.0',
     title: {

--- a/lib/forms/TEN_ITEM_PERSONALITY_INVENTORY/index.ts
+++ b/lib/forms/TEN_ITEM_PERSONALITY_INVENTORY/index.ts
@@ -38,7 +38,7 @@ export default defineInstrument({
   language: ['en', 'fr'],
   internal: {
     name: 'TEN_ITEM_PERSONALITY_INVENTORY',
-    edition: 1
+    edition: 2
   },
   tags: {
     en: [
@@ -60,8 +60,8 @@ export default defineInstrument({
     },
     estimatedDuration: 5,
     instructions: {
-      en: ['Please respond to every question'],
-      fr: ['Veuillez répondre à toutes les questions']
+      en: ['Follow the instructions on the next page'],
+      fr: ['Suivez les instructions de la page suivante']
     },
     license: 'FREE-NOS',
     title: {


### PR DESCRIPTION
This repo's share of DouglasNeuroInformatics/CPPQ#74. Applies the wording @joshunrau proposed and @AnneAlmey accepted — **"Follow the instructions on the next page"** — to the seven `CPP_SERIES` instruments here whose `details.instructions` was generic filler. Instructions can't be dropped entirely, since ODC requires them.

| Instrument | Was | Edition |
| --- | --- | --- |
| `FAGERSTRÖM_NICOTINE_DEPENDENCE` | "Please respond to every question" | 1 → 2 |
| `AUDIT_C` | "Please respond to every question" | 1 → 2 |
| `TEN_ITEM_PERSONALITY_INVENTORY` | "Please respond to every question" | 1 → 2 |
| `GAD_7` | "Please complete all questions" | 1 → 2 |
| `ADHD_ASRS_1.1` | "This is a self-rated instrument, please answer all questions." | 1 → 2 |
| `CUDIT_R` | "Please fill out answer that best describe your cannabis usage." | 1 → 2 |
| `OLDER_AMERICANS_RESOURCES_AND_SERVICES` | "Now, I would like to ask you some questions about your family and friends. Please complete all questions." | 1 → 2 |

For `CUDIT_R` the instructions live in `clientDetails` rather than `details` — that's the block changed.

### Two deliberate judgement calls

The last two rows had text that was arguably more than filler, and applying the agreed wording uniformly was chosen over per-instrument exceptions:

- `OLDER_AMERICANS_RESOURCES_AND_SERVICES` — the "Now, I would like to ask you some questions about your family and friends" lead-in is meaningful; only the trailing "Please complete all questions" was filler.
- `CUDIT_R` — meaningful, though ungrammatical as written.

Both are easy to restore or reword if @AnneAlmey would rather keep them — say so and I'll adjust.

### Out of scope

- All `TMB_*` interactive instruments — "Instructions will be presented on screen in the task." is accurate. (`TMB_MATRIX_REASONING` and `TMB_EMOTION_RECOGNITION` have no `instructions` field at all.)
- `ATHENS_INSOMNIA_SCALE` — no `instructions` field.
- `C3Q`, `SIDAS`, `MODIFIED_SIDAS` — not `CPP_SERIES` members.
- `PHQ_9`, `STARKSTEIN_APATHY_SCALE` — instructions describe a recall period, not filler.

### Series pins

These edition bumps do **not** reach participants on their own — `CPP_SERIES` pins exact editions. A follow-up PR in CPPQ updates the pins once this and its sibling PRs merge. See CPPQ#142 for the evidence that the pin is exact rather than a minimum.

### Verification

`pnpm exec tsc && pnpm exec eslint lib` passes. The one unrelated hunk is a trailing blank line removed from `AUDIT_C/index.ts` by the repo's own prettier pre-commit hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
